### PR TITLE
Install gh from github releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 # Dockerfile used as GitHub action
 FROM python:latest AS base
 
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
-    apt-get update --allow-releaseinfo-change && \
+RUN apt-get update --allow-releaseinfo-change && \
     DEBIAN_FRONTEND="noninteractive" apt-get -yq install \
         bash \
         curl \
         jq \
-        gh && \
+    && t="/tmp/gh-$$.deb" && curl -sSLo "$t" "https://github.com$(curl -sSL "https://github.com/cli/cli/releases/latest" | grep -Po "(?<=href=\")/cli/cli/releases/download/[^\"]*$(dpkg --print-architecture)[.]deb(?=\")")" && apt-get install -y "$t" && rm "$t" \
     rm -rf /var/lib/apt/lists/* $HOME/.python_history $HOME/.wget-hsts
 
 ENV PYTHONPATH="/"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,14 +1,12 @@
 # Dockerfile used for development and testing
 FROM python:latest AS base
 
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
-    apt-get update --allow-releaseinfo-change && \
+RUN apt-get update --allow-releaseinfo-change && \
     DEBIAN_FRONTEND="noninteractive" apt-get -yq install \
         bash \
         curl \
         jq \
-        gh && \
+    && t="/tmp/gh-$$.deb" && curl -sSLo "$t" "https://github.com$(curl -sSL "https://github.com/cli/cli/releases/latest" | grep -Po "(?<=href=\")/cli/cli/releases/download/[^\"]*$(dpkg --print-architecture)[.]deb(?=\")")" && apt-get install -y "$t" && rm "$t" \
     rm -rf /var/lib/apt/lists/* $HOME/.python_history $HOME/.wget-hsts
 
 ENV PYTHONPATH="/"


### PR DESCRIPTION
Fixes issue with expired Debian package signing. Installs gh directly from github releases page. See: https://github.com/cli/cli/issues/6175.

Fixes #5.